### PR TITLE
Support word encoding in parallel with base32 (with shorter dictionary)

### DIFF
--- a/flycrypt.go
+++ b/flycrypt.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/davidlazar/go-crypto/encoding/base32"
+	"github.com/tchajed/wordenc/shortdict"
 	"golang.org/x/crypto/nacl/box"
 )
 
@@ -46,9 +47,12 @@ func key() {
 		log.Fatalf("box.GenerateKey error: %s", err)
 	}
 	pubStr := base32.EncodeToString(public[:])
+	pubWordEncoded := shortdict.EncodeToString(public[:])
 	privStr := base32.EncodeToString(private[:])
 	fmt.Println()
 	fmt.Printf(" Public key: %s\n", pubStr)
+	fmt.Println(pubWordEncoded)
+	fmt.Println()
 	fmt.Printf("Private key: %s (SAVE THIS)\n", privStr)
 }
 
@@ -61,9 +65,12 @@ func encrypt() {
 		log.Fatalf("unable to read key")
 	}
 
-	data, err := base32.DecodeString(strings.TrimSpace(line))
+	data, err := shortdict.DecodeString(line, 32)
 	if err != nil || len(data) != 32 {
-		log.Fatalf("failed to decode key")
+		data, err = base32.DecodeString(strings.TrimSpace(line))
+		if err != nil || len(data) != 32 {
+			log.Fatalf("failed to decode key")
+		}
 	}
 	theirPublic := new([32]byte)
 	copy(theirPublic[:], data)


### PR DESCRIPTION
Uses an 11 bit per word encoding scheme (for a dictionary of size
2048). There is no padding information in the message, but in this
context we can truncate the output to the first 32 bytes.
